### PR TITLE
docs(contrib): add simpler webpack example

### DIFF
--- a/examples/webpack/src/index.js
+++ b/examples/webpack/src/index.js
@@ -4,8 +4,13 @@ import '@vime/core/themes/default.css';
 // Optional light theme (extends default). ~400B
 import '@vime/core/themes/light.css';
 
-import { VimePlayer, VimeVideo, VimeFile } from '@vime/core';
+// Load Vime and register custom elements
+import * as vime from '@vime/core';
+vime.defineCustomElements()
 
-customElements.define('vime-player', VimePlayer);
-customElements.define('vime-video', VimeVideo);
-customElements.define('vime-file', VimeFile);
+// Or import components individually
+// import { VimePlayer, VimeVideo, VimeFile } from '@vime/core';
+
+// customElements.define('vime-player', VimePlayer);
+// customElements.define('vime-video', VimeVideo);
+// customElements.define('vime-file', VimeFile);


### PR DESCRIPTION
I spent too much time trying to figure out how to import into a Webpack project without manually loading every single component separately. Thought I'd be a good user and contribute back an updated example. 👍