### PR TITLE
Update the videoId property in example snippet.

### DIFF
--- a/docs/docs/components/providers/youtube.md
+++ b/docs/docs/components/providers/youtube.md
@@ -43,7 +43,7 @@ values={[
 
 ```html {2}
 <vm-player controls>
-  <vm-youtube video-id="DyTCOwB0DVw"></vm-youtube>
+  <vm-youtube videoId="DyTCOwB0DVw"></vm-youtube>
   <!-- ... -->
 </vm-player>
 ```
@@ -132,7 +132,7 @@ class Example {
 
 ```html {2} title="example.html"
 <vm-player controls>
-  <vm-youtube cookies="true" video-id="DyTCOwB0DVw"></vm-youtube>
+  <vm-youtube cookies="true" videoId="DyTCOwB0DVw"></vm-youtube>
   <!-- ... -->
 </vm-player>
 ```


### PR DESCRIPTION
Currently, in the HTML and Angular snippet, the `videoId` parameter is displayed in the example snippet as `video-id`, which is not true.