### PR TITLE
feat: add cookies props for vimeo provider

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1565,6 +1565,10 @@ export namespace Components {
          */
         "color"?: string;
         "controls": boolean;
+        /**
+          * Whether cookies should be enabled on the embed.
+         */
+        "cookies": boolean;
         "getAdapter": () => Promise<{ getInternalPlayer: () => Promise<HTMLVmEmbedElement>; play: () => Promise<void>; pause: () => Promise<void>; canPlay: (type: any) => Promise<boolean>; setCurrentTime: (time: number) => Promise<void>; setMuted: (muted: boolean) => Promise<void>; setVolume: (volume: number) => Promise<void>; canSetPlaybackRate: () => Promise<boolean>; setPlaybackRate: (rate: number) => Promise<void>; }>;
         "language": string;
         "logger"?: Logger;
@@ -3722,6 +3726,10 @@ declare namespace LocalJSX {
          */
         "color"?: string;
         "controls"?: boolean;
+        /**
+          * Whether cookies should be enabled on the embed.
+         */
+        "cookies"?: boolean;
         "language"?: string;
         "logger"?: Logger;
         "loop"?: boolean;

--- a/core/src/components/providers/vimeo/VimeoParams.ts
+++ b/core/src/components/providers/vimeo/VimeoParams.ts
@@ -144,4 +144,11 @@ export interface VimeoParams {
    * @default undefined
    */
   width?: number;
+
+  /**
+   * Setting this parameter to "true" will block the player from tracking any session data, including all cookies and analytics.
+   *
+   * @default false
+   */
+  dnt?: boolean;
 }

--- a/core/src/components/providers/vimeo/vimeo.tsx
+++ b/core/src/components/providers/vimeo/vimeo.tsx
@@ -125,6 +125,11 @@ export class Vimeo implements MediaProvider<HTMLVmEmbedElement> {
    */
   @Prop() poster?: string;
 
+  /**
+   * Whether cookies should be enabled on the embed.
+   */
+  @Prop() cookies = true;
+
   @Watch('poster')
   onCustomPosterChange() {
     this.dispatch('currentPoster', this.poster);
@@ -214,6 +219,7 @@ export class Vimeo implements MediaProvider<HTMLVmEmbedElement> {
       autoplay: this.autoplay,
       muted: this.initialMuted,
       playsinline: this.playsinline,
+      dnt: !this.cookies,
     };
   }
 


### PR DESCRIPTION
## Feature - Add `cookies` prop for vimeo provider

This PR allow the use of the `dnt` parameter for vimeo ([documentation](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Using-Player-Parameters)).

The vimeo provider has now a new prop named `cookies`, which when turned to false, will prevent vimeo from tracking users.