### PR TITLE
Fix typescript target ES version

### DIFF
--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "ES6",
     "jsxFactory": "h",
     "jsx": "react"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "experimentalDecorators": true,
     "lib": ["DOM", "ES2017"],
     "moduleResolution": "node",
-    "module": "ESNext",
-    "target": "ESNext",
+    "module": "ES6",
+    "target": "ES6",
     "jsx": "react",
     "jsxFactory": "h"
   },


### PR DESCRIPTION
As described in https://github.com/vime-js/vime/issues/209, this is my proposal to fix the current issues with the compiled files being of too high ES standard.

By modifying tsconfig to compile to ES6-standard javascript, we can make sure to create javascript that is fully compatible with modern browsers, webpack < 5 and angular < 12, without need for additional transpiling.

Edit: Note: I'm not very familiar with all pieces and adapters that vime ships with, so I did only do a very simple test: Verified it builds without errors and copied the created build over the previous esnext build within my main project repo.