### PR TITLE
Fix image URLs after packages merge

### DIFF
--- a/packages/core/src/components/ui/captions/captions.tsx
+++ b/packages/core/src/components/ui/captions/captions.tsx
@@ -26,7 +26,7 @@ import { withControlsCollisionDetection } from '../controls/controls/withControl
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/captions/captions.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/captions/captions.png"
  *   alt="Vime captions component"
  * />
  */

--- a/packages/core/src/components/ui/controls/caption-control/caption-control.tsx
+++ b/packages/core/src/components/ui/controls/caption-control/caption-control.tsx
@@ -17,7 +17,7 @@ import { KeyboardControl } from '../control/KeyboardControl';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/caption-control/caption-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/caption-control/caption-control.png"
  *   alt="Vime caption control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/control-group/control-group.tsx
+++ b/packages/core/src/components/ui/controls/control-group/control-group.tsx
@@ -9,7 +9,7 @@ import { withComponentRegistry } from '../../../core/player/withComponentRegistr
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/control-group/control-group.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/control-group/control-group.png"
  *   alt="Vime control group component"
  * />
  */

--- a/packages/core/src/components/ui/controls/control-spacer/control-spacer.tsx
+++ b/packages/core/src/components/ui/controls/control-spacer/control-spacer.tsx
@@ -8,7 +8,7 @@ import { withComponentRegistry } from '../../../core/player/withComponentRegistr
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/control-spacer/control-spacer.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/control-spacer/control-spacer.png"
  *   alt="Vime control spacer component"
  * />
  */

--- a/packages/core/src/components/ui/controls/control/control.tsx
+++ b/packages/core/src/components/ui/controls/control/control.tsx
@@ -26,7 +26,7 @@ import { KeyboardControl } from './KeyboardControl';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/control/control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/control/control.png"
  *   alt="Vime control component"
  * />
  *

--- a/packages/core/src/components/ui/controls/controls/controls.tsx
+++ b/packages/core/src/components/ui/controls/controls/controls.tsx
@@ -26,7 +26,7 @@ const hideControlsTimeout: Record<any, number | undefined> = {};
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/controls/controls.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/controls/controls.png"
  *   alt="Vime controls component"
  * />
  *

--- a/packages/core/src/components/ui/controls/fullscreen-control/fullscreen-control.tsx
+++ b/packages/core/src/components/ui/controls/fullscreen-control/fullscreen-control.tsx
@@ -17,7 +17,7 @@ import { KeyboardControl } from '../control/KeyboardControl';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/fullscreen-control/fullscreen-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/fullscreen-control/fullscreen-control.png"
  *   alt="Vime fullscreen control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/mute-control/mute-control.tsx
+++ b/packages/core/src/components/ui/controls/mute-control/mute-control.tsx
@@ -18,7 +18,7 @@ import { KeyboardControl } from '../control/KeyboardControl';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/mute-control/mute-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/mute-control/mute-control.png"
  *   alt="Vime mute control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/pip-control/pip-control.tsx
+++ b/packages/core/src/components/ui/controls/pip-control/pip-control.tsx
@@ -17,7 +17,7 @@ import { KeyboardControl } from '../control/KeyboardControl';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/pip-control/pip-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/pip-control/pip-control.png"
  *   alt="Vime mute control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/playback-control/playback-control.tsx
+++ b/packages/core/src/components/ui/controls/playback-control/playback-control.tsx
@@ -17,7 +17,7 @@ import { KeyboardControl } from '../control/KeyboardControl';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/playback-control/playback-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/playback-control/playback-control.png"
  *   alt="Vime playback control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/scrubber-control/scrubber-control.tsx
+++ b/packages/core/src/components/ui/controls/scrubber-control/scrubber-control.tsx
@@ -24,7 +24,7 @@ import { withPlayerContext } from '../../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/scrubber-control/scrubber-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/scrubber-control/scrubber-control.png"
  *   alt="Vime scrubber control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/settings-control/settings-control.tsx
+++ b/packages/core/src/components/ui/controls/settings-control/settings-control.tsx
@@ -26,7 +26,7 @@ let idCount = 0;
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/settings-control/settings-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/settings-control/settings-control.png"
  *   alt="Vime settings control component"
  * />
  */

--- a/packages/core/src/components/ui/controls/volume-control/volume-control.tsx
+++ b/packages/core/src/components/ui/controls/volume-control/volume-control.tsx
@@ -19,7 +19,7 @@ import { TooltipDirection, TooltipPosition } from '../../tooltip/types';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/controls/volume-control/volume-control.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/controls/volume-control/volume-control.png"
  *   alt="Vime volume control component"
  * />
  */

--- a/packages/core/src/components/ui/default-ui/default-ui.tsx
+++ b/packages/core/src/components/ui/default-ui/default-ui.tsx
@@ -14,21 +14,21 @@ import { withComponentRegistry } from '../../core/player/withComponentRegistry';
  * ### Audio
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/default-ui/default-ui--audio.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/default-ui/default-ui--audio.png"
  *   alt="Vime default audio player"
  * />
  *
  * ### Desktop Video
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/default-ui/default-ui--desktop.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/default-ui/default-ui--desktop.png"
  *   alt="Vime default desktop video player"
  * />
  *
  * ### Mobile Video
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/default-ui/default-ui--mobile.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/default-ui/default-ui--mobile.png"
  *   alt="Vime default desktop mobile player"
  * />
  *

--- a/packages/core/src/components/ui/live-indicator/live-indicator.tsx
+++ b/packages/core/src/components/ui/live-indicator/live-indicator.tsx
@@ -10,7 +10,7 @@ import { withPlayerContext } from '../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/live-indicator/live-indicator.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/live-indicator/live-indicator.png"
  *   alt="Vime live indicator component"
  * />
  */

--- a/packages/core/src/components/ui/poster/poster.tsx
+++ b/packages/core/src/components/ui/poster/poster.tsx
@@ -22,7 +22,7 @@ import { withPlayerContext } from '../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/poster/poster.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/poster/poster.png"
  *   alt="Vime poster component"
  * />
  */

--- a/packages/core/src/components/ui/settings/default-settings/default-settings.tsx
+++ b/packages/core/src/components/ui/settings/default-settings/default-settings.tsx
@@ -24,7 +24,7 @@ import { withPlayerContext } from '../../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/default-settings/default-settings.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/default-settings/default-settings.png"
  *   alt="Vime default settings component"
  * />
  *

--- a/packages/core/src/components/ui/settings/menu-item/menu-item.tsx
+++ b/packages/core/src/components/ui/settings/menu-item/menu-item.tsx
@@ -21,7 +21,7 @@ import { withPlayerContext } from '../../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/menu-radio-group/menu-radio-group.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/menu-radio-group/menu-radio-group.png"
  *   alt="Vime settings menu radio group component"
  * />
  */

--- a/packages/core/src/components/ui/settings/menu-radio-group/menu-radio-group.tsx
+++ b/packages/core/src/components/ui/settings/menu-radio-group/menu-radio-group.tsx
@@ -23,7 +23,7 @@ import { withComponentRegistry } from '../../../core/player/withComponentRegistr
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/menu/menu.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/menu/menu.png"
  *   alt="Vime settings menu component"
  * />
  *

--- a/packages/core/src/components/ui/settings/menu-radio/menu-radio.tsx
+++ b/packages/core/src/components/ui/settings/menu-radio/menu-radio.tsx
@@ -9,7 +9,7 @@ import { withComponentRegistry } from '../../../core/player/withComponentRegistr
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/menu-radio/menu-radio.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/menu-radio/menu-radio.png"
  *   alt="Vime settings menu radio component"
  * />
  */

--- a/packages/core/src/components/ui/settings/menu/menu.tsx
+++ b/packages/core/src/components/ui/settings/menu/menu.tsx
@@ -32,7 +32,7 @@ import { menuItemHunter } from './menuItemHunter';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/menu-item/menu-item.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/menu-item/menu-item.png"
  *   alt="Vime settings menu item component"
  * />
  *

--- a/packages/core/src/components/ui/settings/settings/settings.tsx
+++ b/packages/core/src/components/ui/settings/settings/settings.tsx
@@ -32,7 +32,7 @@ let idCount = 0;
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/settings/settings.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/settings/settings.png"
  *   alt="Vime settings component"
  * />
  *

--- a/packages/core/src/components/ui/settings/submenu/submenu.tsx
+++ b/packages/core/src/components/ui/settings/submenu/submenu.tsx
@@ -22,7 +22,7 @@ let idCount = 0;
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/settings/submenu/submenu.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/settings/submenu/submenu.png"
  *   alt="Vime submenu component"
  * />
  *

--- a/packages/core/src/components/ui/spinner/spinner.tsx
+++ b/packages/core/src/components/ui/spinner/spinner.tsx
@@ -19,7 +19,7 @@ import { Provider } from '../../providers/Provider';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/spinner/spinner.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/spinner/spinner.png"
  *   alt="Vime spinner component"
  * />
  */

--- a/packages/core/src/components/ui/time/current-time/current-time.tsx
+++ b/packages/core/src/components/ui/time/current-time/current-time.tsx
@@ -10,7 +10,7 @@ import { withPlayerContext } from '../../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/time/current-time/current-time.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/time/current-time/current-time.png"
  *   alt="Vime current time component"
  * />
  */

--- a/packages/core/src/components/ui/time/end-time/end-time.tsx
+++ b/packages/core/src/components/ui/time/end-time/end-time.tsx
@@ -10,7 +10,7 @@ import { withPlayerContext } from '../../../core/player/withPlayerContext';
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/time/end-time/end-time.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/time/end-time/end-time.png"
  *   alt="Vime end time component"
  * />
  */

--- a/packages/core/src/components/ui/time/time-progress/time-progress.tsx
+++ b/packages/core/src/components/ui/time/time-progress/time-progress.tsx
@@ -8,7 +8,7 @@ import { withComponentRegistry } from '../../../core/player/withComponentRegistr
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/time/time/time.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/time/time/time.png"
  *   alt="Vime time component"
  * />
  */

--- a/packages/core/src/components/ui/time/time/time.tsx
+++ b/packages/core/src/components/ui/time/time/time.tsx
@@ -9,7 +9,7 @@ import { withComponentRegistry } from '../../../core/player/withComponentRegistr
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/time/time-progress/time-progress.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/time/time-progress/time-progress.png"
  *   alt="Vime time progress component"
  * />
  */

--- a/packages/core/src/components/ui/tooltip/tooltip.tsx
+++ b/packages/core/src/components/ui/tooltip/tooltip.tsx
@@ -15,7 +15,7 @@ let tooltipIdCount = 0;
  * ## Visual
  *
  * <img
- *   src="https://raw.githubusercontent.com/vime-js/vime/master/src/components/ui/tooltip/tooltip.png"
+ *   src="https://raw.githubusercontent.com/vime-js/vime/master/packages/core/src/components/ui/tooltip/tooltip.png"
  *   alt="Vime tooltip component"
  * />
  *


### PR DESCRIPTION
The docs still contain hardcoded URLs to what looks like a pre-split
version of code.

This only fixes for the current docs, not the legacy (4.x, etc.)

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Buggy image URLs

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 234

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Images now show correctly

## Does this introduce a breaking change?

- [ ] Yes
- [ X] No
