### PR TITLE
Fix menuitem case to MenuItem

### DIFF
--- a/docs/docs/getting-started/settings.md
+++ b/docs/docs/getting-started/settings.md
@@ -335,9 +335,9 @@ function Player() {
 
     <DefaultUi noSettings>
       <Settings>
-        <menuitem label="Menu Item 1" badge="BADGE" @click="onMenuItem1Click" />
+        <MenuItem label="Menu Item 1" badge="BADGE" @click="onMenuItem1Click" />
 
-        <menuitem label="Menu Item 2" hint="Hint" @click="onMenuItem2Click" />
+        <MenuItem label="Menu Item 2" hint="Hint" @click="onMenuItem2Click" />
 
         <Submenu label="Submenu 1" :hint="value">
           <MenuRadioGroup :value="value" @vCheck="onCheck">
@@ -403,13 +403,13 @@ function Player() {
 
   <DefaultUi noSettings>
     <Settings>
-      <menuitem
+      <MenuItem
         label="Menu Item 1"
         badge="BADGE"
         on:click="{onMenuItem1Click}"
       />
 
-      <menuitem label="Menu Item 2" hint="Hint" on:click="{onMenuItem2Click}" />
+      <MenuItem label="Menu Item 2" hint="Hint" on:click="{onMenuItem2Click}" />
 
       <Submenu label="Submenu 1" hint="{value}">
         <MenuRadioGroup {value} on:vCheck="{onCheck}">


### PR DESCRIPTION
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

MenuItem is not displayed is vue and svelte, because of using the wrong case

Issue Number: N/A

## What is the new behavior?

MenuItem is displayed

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
