### PR TITLE
fix(settings-menu): set pointer-events to none when settings menu is …

### DIFF
--- a/packages/core/src/components/ui/settings/settings/settings.css
+++ b/packages/core/src/components/ui/settings/settings/settings.css
@@ -22,7 +22,7 @@
 .settings {
   position: absolute;
   opacity: 0;
-  pointer-events: auto;
+  pointer-events: none;
   overflow-x: hidden;
   overflow-y: auto;
   background-color: var(--vm-menu-bg);
@@ -68,6 +68,7 @@
 .settings.active {
   transform: translateY(0);
   opacity: 1;
+  pointer-events: auto;
   visibility: visible !important;
 }
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When using vime as an audio player, the settings menu prevents clicking or interacting with other UI elements behind it when it is not visible.

Issue Number: N/A

## What is the new behavior?

By setting `pointer-events: none` to the settings menu, elements behind it are now clickable.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A
