### PR TITLE
Issue294 - Add flex-end to ts def 

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -190,6 +190,7 @@ export namespace Components {
         "justify": | 'start'
     | 'center'
     | 'end'
+    | 'flex-end'
     | 'space-around'
     | 'space-between'
     | 'space-evenly';
@@ -2181,6 +2182,7 @@ declare namespace LocalJSX {
         "justify"?: | 'start'
     | 'center'
     | 'end'
+    | 'flex-end'
     | 'space-around'
     | 'space-between'
     | 'space-evenly';

--- a/packages/core/src/components/ui/controls/controls/controls.tsx
+++ b/packages/core/src/components/ui/controls/controls/controls.tsx
@@ -79,6 +79,7 @@ export class Controls {
     | 'start'
     | 'center'
     | 'end'
+    | 'flex-end'
     | 'space-around'
     | 'space-between'
     | 'space-evenly' = 'start';


### PR DESCRIPTION
## Pull request type

## What is the current behavior?

Webkit needs justify="flex-end" instead of justify="end" to work well... missing typescript support for flex-end

## What is the new behavior?

Added flex-end to types definition

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

