### PR TITLE
Fix default theme link in docs

### DIFF
--- a/docs/docs/getting-started/styling.md
+++ b/docs/docs/getting-started/styling.md
@@ -109,7 +109,7 @@ vm-player[theme='light'] {
 }
 ```
 
-[default-theme]: https://github.com/vime-js/vime/blob/src/themes/default.css
+[default-theme]: https://github.com/vime-js/vime/blob/main/packages/core/src/themes/default.css
 
 ## Icons
 


### PR DESCRIPTION
The default theme has been moved to the `core` package.

## Pull request type
Docs fix