### PR TITLE
fix: update jsdelivr to unpkg as jsdelivr is blocked in some regions

### DIFF
--- a/packages/core/src/components/providers/dash/dash.tsx
+++ b/packages/core/src/components/providers/dash/dash.tsx
@@ -189,7 +189,7 @@ export class Dash implements MediaFileProvider<any> {
     try {
       const url =
         this.libSrc ||
-        `https://cdn.jsdelivr.net/npm/dashjs@${this.version}/dist/dash.all.min.js`;
+        `https://unpkg.com/dashjs@${this.version}/dist/dash.all.min.js`;
 
       const DashSDK = (await loadSDK(url, 'dashjs')) as any;
 

--- a/packages/core/src/components/providers/hls/hls.tsx
+++ b/packages/core/src/components/providers/hls/hls.tsx
@@ -136,7 +136,7 @@ export class HLS implements MediaFileProvider {
     try {
       const url =
         this.libSrc ||
-        `https://cdn.jsdelivr.net/npm/hls.js@${this.version}/dist/hls.min.js`;
+        `https://unpkg.com/hls.js@${this.version}/dist/hls.min.js`;
 
       const Hls = (await loadSDK(url, 'Hls')) as any;
 

--- a/packages/core/src/components/ui/icon-library/IconRegistry.ts
+++ b/packages/core/src/components/ui/icon-library/IconRegistry.ts
@@ -12,7 +12,7 @@ export type IconLibraryResolver = (name: string) => string;
 export const ICONS_BASE_CDN_URL =
   process.env.NODE_ENV === 'development'
     ? '/icons'
-    : 'https://cdn.jsdelivr.net/npm/@vime/core@latest/icons';
+    : 'https://unpkg.com/@vime/core@5.3.1/icons';
 
 const registry = new Map<string, IconLibraryResolver>(
   Object.entries({


### PR DESCRIPTION
## Pull request type

Critical Fix

## What is the current behavior?

Some of the player providers load content from cdn.jsdelivr.net, which is blocked in China and some other regions. Which doesn't let the videoplayer to play videos.

## What is the new behavior?

Libraries like hls and dash will load lib from unpkg and the video plays irrespective of region.

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->