### PR TITLE
fix(react): InitialMuted set on componentWillLoad

### DIFF
--- a/packages/core/src/components/providers/dailymotion/dailymotion.tsx
+++ b/packages/core/src/components/providers/dailymotion/dailymotion.tsx
@@ -190,7 +190,7 @@ export class Dailymotion implements MediaProvider<HTMLVmEmbedElement> {
     this.defaultInternalState = { ...this.internalState };
   }
 
-  componentDidLoad() {
+  componentWillLoad() {
     this.initialMuted = this.muted;
   }
 

--- a/packages/core/src/components/providers/vimeo/vimeo.tsx
+++ b/packages/core/src/components/providers/vimeo/vimeo.tsx
@@ -187,7 +187,7 @@ export class Vimeo implements MediaProvider<HTMLVmEmbedElement> {
     this.defaultInternalState = { ...this.internalState };
   }
 
-  componentDidLoad() {
+  componentWillLoad() {
     this.initialMuted = this.muted;
   }
 

--- a/packages/core/src/components/providers/youtube/youtube.tsx
+++ b/packages/core/src/components/providers/youtube/youtube.tsx
@@ -148,7 +148,7 @@ export class YouTube implements MediaProvider<HTMLVmEmbedElement> {
     this.defaultInternalState = { ...this.internalState };
   }
 
-  componentDidLoad() {
+  componentWillLoad() {
     this.initialMuted = this.muted;
   }
 


### PR DESCRIPTION
Fixes https://github.com/vime-js/vime/issues/320

## Pull request type

## What is the current behavior?
Initial muted was set on component loaded

## What is the new behavior?

Initial muted is now set before component load

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
