### PR TITLE
Update tsconfig.json

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "dist",
     "removeComments": false,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "target": "ES6"
   },
   "include": ["src"]


### PR DESCRIPTION
## Pull request type

## What is the current behavior?

lot of warning in webpack build + dev
exemple:
```
WARNING in ./node_modules/@vime/react/dist/esm/lib.jsx
Module Warning (from ./node_modules/react-scripts/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from 'XXX/node_modules/@vime/react/src/lib.tsx' file: Error: ENOENT: no such file or directory, open 'XXX/node_modules/@vime/react/src/lib.tsx'
```

This is mainly due to the the fact that the src aren't shipped to npm. we either include the src or we don't ship any sourcemap

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Do not ship sourcemap

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
