### PR TITLE
fix: Dailymotion qualities selector.

### DIFF
--- a/packages/core/src/utils/network.ts
+++ b/packages/core/src/utils/network.ts
@@ -108,11 +108,20 @@ export const parseQueryString = <T>(qs?: string): T => {
       ? tryDecodeURIComponent(match[2].replace(/\+/g, ' '), match[2])
       : '';
 
-    const currValue = params[name];
+    // Check if the key contains '[' and ']' indicating it's an array entry
+    if (name.includes('[') && name.includes(']')) {
+      const baseName = name.split('[')[0];
+      if (!params[baseName]) {
+        params[baseName] = [];
+      }
+      params[baseName].push(value);
+    } else {
+      const currValue = params[name];
 
-    if (currValue && !isArray(currValue)) params[name] = [currValue];
-
-    currValue ? params[name].push(value) : (params[name] = value);
+      if (currValue && !isArray(currValue)) params[name] = [currValue];
+      
+      isArray(params[name]) ? params[name].push(value) : (params[name] = value);
+    }
   }
 
   return params;


### PR DESCRIPTION
## Pull request type

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The playback quality selector is not working.

The error is happening because the query is not decoded correctly in `parseQueryString`. Then in the file below we get a `Cannot read properties of undefined` besause `qualities` doesn't exist.

https://github.com/vime-js/vime/blob/0d0df2e861e3378756b9a5df048e753f7289592c/packages/core/src/components/providers/dailymotion/dailymotion.tsx#L338-L343

Input:
```
event=qualitiesavailable&qualities%5B0%5D=1080&qualities%5B1%5D=720&qualities%5B2%5D=480&qualities%5B3%5D=380
```
before
```json
{
    "event": "qualitiesavailable",
    "qualities[0]": "1080",
    "qualities[1]": "720",
    "qualities[2]": "480",
    "qualities[3]": "380"
}
```
after
```json
{
    "event": "qualitiesavailable",
    "qualities": [
        "1080",
        "720",
        "480",
        "380"
    ]
}
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Fix the playback quality selector.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Before the list of qualities is not displayed:

![image](https://github.com/vime-js/vime/assets/38622893/08e440dc-d23f-408f-b541-cda0df082eae)

After the change:

![image](https://github.com/vime-js/vime/assets/38622893/dcdf777f-c7d0-4213-a8dc-9e023c9b3fce)

