### PR TITLE
feat: expose params to youtube component

### DIFF
--- a/packages/core/src/components/providers/youtube/youtube.tsx
+++ b/packages/core/src/components/providers/youtube/youtube.tsx
@@ -75,6 +75,10 @@ export class YouTube implements MediaProvider<HTMLVmEmbedElement> {
   @State() mediaTitle = '';
 
   /**
+   * YouTube params to overwrite
+   */
+  @Prop() params?: YouTubeParams = {};
+  /**
    * Whether cookies should be enabled on the embed.
    */
   @Prop() cookies = false;
@@ -227,6 +231,7 @@ export class YouTube implements MediaProvider<HTMLVmEmbedElement> {
       mute: this.initialMuted ? 1 : 0,
       playsinline: this.playsinline ? 1 : 0,
       autoplay: this.autoplay ? 1 : 0,
+      ...this.params,
     };
   }
 


### PR DESCRIPTION
## Pull request type

## What is the current behavior?
Youtube params are set internally, so you can't adjust them unless you use the vm-embed component

## What is the new behavior?
You can now override the youtube params via the prop

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
I added this feature because I wanted to be able to include the "rel=0" param to prevent YouTube from displaying suggested videos after my video. The default in vime is "rel=1" which means it will show the related videos after your youtube video plays.
https://github.com/vime-js/vime/blob/c1f311950c52b5c49329873a6bb9739f3727223f/packages/core/src/components/providers/youtube/YouTubeParams.ts#L228-L235

## Related 
https://github.com/vime-js/vime/issues/79